### PR TITLE
refactor: sales orders 明細行構造, 登録ロジック改良

### DIFF
--- a/src/app/Http/Controllers/SalesOrderController.php
+++ b/src/app/Http/Controllers/SalesOrderController.php
@@ -52,7 +52,6 @@ class SalesOrderController extends Controller
         ]);
     }
 
-    /** 紐付き受発注対応 */
     public function store(SalesOrderStoreRequest $request): RedirectResponse
     {
         // TODO: トランザクションにまとめて登録処理
@@ -83,7 +82,7 @@ class SalesOrderController extends Controller
 
     /*
     |--------------------------------------------------------------------------
-    | other methods
+    | Business Logic
     |--------------------------------------------------------------------------
     */
 
@@ -117,6 +116,9 @@ class SalesOrderController extends Controller
         ]);
     }
 
+    /**
+     * 明細行（受注明細・発注・発注明細）の紐付き受発注登録処理。明細行は多くて10~20程度の想定,パフォーマンス影響小。
+     */
     private function createDetailRows(SalesOrder $salesOrder, array $detailRows): void
     {
         collect($detailRows)->each(function ($detailRow, $index) use ($salesOrder) {
@@ -127,7 +129,7 @@ class SalesOrderController extends Controller
         });
     }
 
-    /** 受注明細登録 */
+    /** 受注明細 */
     private function createSalesOrderDetail(array $salesOrderDetail, SalesOrder $salesOrder, int $index): SalesOrderDetail
     {
         return $salesOrder->salesOrderDetails()->create([
@@ -143,7 +145,7 @@ class SalesOrderController extends Controller
         ]);
     }
 
-    /** 紐付き発注登録 */
+    /** 発注 */
     private function createPurchaseOrder(array $purchaseOrder, SalesOrderDetail $salesOrderDetail): PurchaseOrder
     {
         return PurchaseOrder::create([
@@ -168,7 +170,7 @@ class SalesOrderController extends Controller
         ]);
     }
 
-    /** 紐付き発注明細登録 */
+    /** 発注明細 */
     private function createPurchaseOrderDetail(array $purchaseOrderDetail, PurchaseOrder $purchaseOrder, int $index): PurchaseOrderDetail
     {
         return $purchaseOrder->purchaseOrderDetails()->create([

--- a/src/app/Http/Controllers/SalesOrderController.php
+++ b/src/app/Http/Controllers/SalesOrderController.php
@@ -56,9 +56,8 @@ class SalesOrderController extends Controller
     public function store(SalesOrderStoreRequest $request): RedirectResponse
     {
         // TODO: トランザクションにまとめて登録処理
-        $detailRows = $request->input('detail_rows');
         $salesOrder = $this->createSalesOrder($request);
-        $this->createDetailRows($detailRows, $salesOrder);
+        $this->createDetailRows($salesOrder, $request->input('detail_rows'));
 
         return to_route('sales-orders.index')
             ->with('message', "受注ID:{$salesOrder->id} 登録成功しました。");
@@ -118,7 +117,7 @@ class SalesOrderController extends Controller
         ]);
     }
 
-    private function createDetailRows(array $detailRows, SalesOrder $salesOrder): void
+    private function createDetailRows(SalesOrder $salesOrder, array $detailRows): void
     {
         collect($detailRows)->each(function ($detailRow, $index) use ($salesOrder) {
             $salesOrderDetail    = $this->createSalesOrderDetail($detailRow['sales_order_detail'], $salesOrder, $index);

--- a/src/app/Http/Controllers/SalesOrderController.php
+++ b/src/app/Http/Controllers/SalesOrderController.php
@@ -55,6 +55,8 @@ class SalesOrderController extends Controller
     /** 紐付き受発注対応 */
     public function store(SalesOrderStoreRequest $request): RedirectResponse
     {
+        dd($request->all()); // TODO: リクエスト構造変更後の修正
+
         // TODO: トランザクションにまとめて登録処理
         $salesOrder           = self::createSalesOrder($request);
         $salesOrderDetails    = self::createSalesOrderDetails($request, $salesOrder->id);

--- a/src/app/Http/Controllers/SalesOrderController.php
+++ b/src/app/Http/Controllers/SalesOrderController.php
@@ -12,6 +12,7 @@ use App\Models\SalesOrder;
 use App\Models\SalesOrderDetail;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -54,9 +55,11 @@ class SalesOrderController extends Controller
 
     public function store(SalesOrderStoreRequest $request): RedirectResponse
     {
-        // TODO: トランザクションにまとめて登録処理
-        $salesOrder = $this->createSalesOrder($request);
-        $this->createDetailRows($salesOrder, $request->input('detail_rows'));
+        $salesOrder = DB::transaction(function () use ($request) {
+            $salesOrder = $this->createSalesOrder($request);
+            $this->createDetailRows($salesOrder, $request->input('detail_rows'));
+            return $salesOrder;
+        });
 
         return to_route('sales-orders.index')
             ->with('message', "受注ID:{$salesOrder->id} 登録成功しました。");

--- a/src/app/Http/Requests/SalesOrderStoreRequest.php
+++ b/src/app/Http/Requests/SalesOrderStoreRequest.php
@@ -66,8 +66,8 @@ class SalesOrderStoreRequest extends FormRequest
             'detail_rows.*.purchase_order.purchase_in_charge_id' => ['required', 'integer', 'exists:users,id'],
 
             // PurchaseOrderDetail
-            'detail_rows.*.purchase_order_detail.quantity'         => ['required', 'numeric', 'min:0.01', 'max:99999999'], // TODO: 0も入力可能にする
-            'detail_rows.*.purchase_order_detail.unit_price'       => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'detail_rows.*.purchase_order_detail.quantity'         => ['required', 'numeric', 'min:0', 'max:99999999'],
+            'detail_rows.*.purchase_order_detail.unit_price'       => ['required', 'numeric', 'min:0', 'max:99999999'],
             'detail_rows.*.purchase_order_detail.tax_rate'         => ['numeric', 'max:1'],
             'detail_rows.*.purchase_order_detail.is_tax_inclusive' => ['boolean'],
             'detail_rows.*.purchase_order_detail.note'             => ['nullable', 'string', 'max:255'],
@@ -81,13 +81,12 @@ class SalesOrderStoreRequest extends FormRequest
      */
     public function attributes(): array
     {
-        // TODO: 表記を統一する
         return [
-            'customer_contact_id'   => '連絡先ID',
-            'billing_address_id'    => '請求先ID',
-            'delivery_address_id'   => '納品先ID',
-            'product_category_id'   => '集計品目ID',
-            'billing_type'          => '請求タイプ',
+            'customer_contact_id'   => '連絡先',
+            'billing_address_id'    => '請求先',
+            'delivery_address_id'   => '納品先',
+            'product_category_id'   => '商品カテゴリ',
+            'billing_type'          => '請求条件',
             'cutoff_day'            => '締め日',
             'payment_month_offset'  => '支払月',
             'payment_day'           => '支払日',
@@ -95,16 +94,15 @@ class SalesOrderStoreRequest extends FormRequest
             'payment_date'          => '入金日',
             'payment_status'        => '入金状況',
             'customer_name'         => '販売先名',
-            'delivery_address'      => '納品先住所',
+            'delivery_address'      => '納品先',
             'order_date'            => '受注日',
             'shipping_date'         => '出荷日',
             'shipping_status'       => '出荷状況',
             'delivery_date'         => '納品日',
             'delivery_status'       => '納品状況',
             'delivery_memo'         => '配送メモ',
-            'total_amount'          => '総合計金額',
             'note'                  => '備考',
-            'sales_in_charge_id'    => '受注担当者ID',
+            'sales_in_charge_id'    => '受注担当者',
         ];
     }
 }

--- a/src/app/Http/Requests/SalesOrderStoreRequest.php
+++ b/src/app/Http/Requests/SalesOrderStoreRequest.php
@@ -50,27 +50,27 @@ class SalesOrderStoreRequest extends FormRequest
             'sales_in_charge_id'    => ['required', 'integer', 'exists:users,id'],
 
             // SalesOrderDetail
-            'sales_order_details.*.product_id'       => ['nullable', 'integer', 'exists:products,id'],
-            'sales_order_details.*.product_name'     => ['required', 'string', 'max:255'],
-            'sales_order_details.*.product_detail'   => ['nullable', 'string', 'max:255'],
-            'sales_order_details.*.quantity'         => ['required', 'numeric', 'min:0.01', 'max:99999999'],
-            'sales_order_details.*.unit_price'       => ['required', 'numeric', 'min:0.01', 'max:99999999'],
-            'sales_order_details.*.tax_rate'         => ['numeric', 'max:1'],
-            'sales_order_details.*.is_tax_inclusive' => ['boolean'],
-            'sales_order_details.*.note'             => ['nullable', 'string', 'max:255'],
+            'detail_rows.*.sales_order_detail.product_id'       => ['nullable', 'integer', 'exists:products,id'],
+            'detail_rows.*.sales_order_detail.product_name'     => ['required', 'string', 'max:255'],
+            'detail_rows.*.sales_order_detail.product_detail'   => ['nullable', 'string', 'max:255'],
+            'detail_rows.*.sales_order_detail.quantity'         => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'detail_rows.*.sales_order_detail.unit_price'       => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'detail_rows.*.sales_order_detail.tax_rate'         => ['numeric', 'max:1'],
+            'detail_rows.*.sales_order_detail.is_tax_inclusive' => ['boolean'],
+            'detail_rows.*.sales_order_detail.note'             => ['nullable', 'string', 'max:255'],
 
             // PurchaseOrder
-            'sales_order_details.*.purchase_order.customer_id'           => ['required', 'integer', 'exists:customers,id'],
-            'sales_order_details.*.purchase_order.customer_contact_id'   => ['required', 'integer', 'exists:customer_contacts,id'],
-            'sales_order_details.*.purchase_order.delivery_address_id'   => ['required', 'integer', 'exists:delivery_addresses,id'],
-            'sales_order_details.*.purchase_order.purchase_in_charge_id' => ['required', 'integer', 'exists:users,id'],
+            'detail_rows.*.purchase_order.customer_id'           => ['required', 'integer', 'exists:customers,id'],
+            'detail_rows.*.purchase_order.customer_contact_id'   => ['required', 'integer', 'exists:customer_contacts,id'],
+            'detail_rows.*.purchase_order.delivery_address_id'   => ['required', 'integer', 'exists:delivery_addresses,id'],
+            'detail_rows.*.purchase_order.purchase_in_charge_id' => ['required', 'integer', 'exists:users,id'],
 
             // PurchaseOrderDetail
-            'sales_order_details.*.purchase_order.purchase_order_details.quantity'         => ['required', 'numeric', 'min:0.01', 'max:99999999'],
-            'sales_order_details.*.purchase_order.purchase_order_details.unit_price'       => ['required', 'numeric', 'min:0.01', 'max:99999999'],
-            'sales_order_details.*.purchase_order.purchase_order_details.tax_rate'         => ['numeric', 'max:1'],
-            'sales_order_details.*.purchase_order.purchase_order_details.is_tax_inclusive' => ['boolean'],
-            'sales_order_details.*.purchase_order.purchase_order_details.note'             => ['nullable', 'string', 'max:255'],
+            'detail_rows.*.purchase_order_detail.quantity'         => ['required', 'numeric', 'min:0.01', 'max:99999999'], // TODO: 0も入力可能にする
+            'detail_rows.*.purchase_order_detail.unit_price'       => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'detail_rows.*.purchase_order_detail.tax_rate'         => ['numeric', 'max:1'],
+            'detail_rows.*.purchase_order_detail.is_tax_inclusive' => ['boolean'],
+            'detail_rows.*.purchase_order_detail.note'             => ['nullable', 'string', 'max:255'],
         ];
     }
 
@@ -81,6 +81,7 @@ class SalesOrderStoreRequest extends FormRequest
      */
     public function attributes(): array
     {
+        // TODO: 表記を統一する
         return [
             'customer_contact_id'   => '連絡先ID',
             'billing_address_id'    => '請求先ID',

--- a/src/lang/ja/validation.php
+++ b/src/lang/ja/validation.php
@@ -159,18 +159,7 @@ return [
             'integer'     => '整数で指定してください',
             'numeric'     => '数字を指定してください',
         ],
-        'sales_order_details.*' => [
-            'required'  => '必須項目です',
-            'exists'    => '存在しない値が選択されました',
-            'max'       => [
-                'numeric' => ':max以下の数字を指定してください',
-                'string'  => ':max文字以下で指定してください',
-                'array'   => ':max個以下指定してください',
-            ],
-            'integer'     => '整数で指定してください',
-            'numeric'     => '数字を指定してください',
-        ],
-        'purchase_order_details.*' => [
+        'detail_rows.*' => [
             'required'  => '必須項目です',
             'exists'    => '存在しない値が選択されました',
             'max'       => [

--- a/src/resources/js/Pages/SalesOrder/Create.jsx
+++ b/src/resources/js/Pages/SalesOrder/Create.jsx
@@ -29,6 +29,34 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
   const [supplierContacts, setSupplierContacts] = useState([]);
   const [supplierAddresses, setSupplierAddresses] = useState([]);
 
+  const defaultRowValues = {
+    sales_order_detail: {
+      product_id: '',
+      product_name: '',
+      product_detail: '',
+      quantity: '',
+      unit_price: '',
+      tax_rate: 0.10,
+      is_tax_inclusive: false,
+      note: '',
+    },
+    purchase_order: {
+      customer_id: '',
+      customer_name: '',
+      customer_contact_id: '',
+      billing_address_id: '',
+      delivery_address_id: '',
+      purchase_in_charge_id: '',
+    },
+    purchase_order_detail: {
+      quantity: '',
+      unit_price: '',
+      tax_rate: 0.10,
+      is_tax_inclusive: false,
+      note: '',
+    }
+  }
+
   const { data, setData, post, processing, errors, reset, isDirty } = useForm({
     customer_id: '',
     customer_name: '',
@@ -52,31 +80,7 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
     delivery_memo: '',
     note: '',
     sales_in_charge_id: '',
-    sales_order_details: [{
-      product_id: '',
-      product_name: '',
-      product_detail: '',
-      quantity: '',
-      unit_price: '',
-      tax_rate: 0.10,
-      is_tax_inclusive: false,
-      note: '',
-      purchase_order: {
-        customer_id: '',
-        customer_name: '',
-        customer_contact_id: '',
-        billing_address_id: '',
-        delivery_address_id: '',
-        purchase_in_charge_id: '',
-        purchase_order_details: {
-          quantity: '',
-          unit_price: '',
-          tax_rate: 0.10,
-          is_tax_inclusive: false,
-          note: '',
-        },
-      },
-    }],
+    detail_rows: [defaultRowValues],
   });
 
   function submit(e) {
@@ -110,80 +114,69 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
   }
 
   function selectSupplier(supplier) {
-    const purchaseOrder = {
-      ...data.sales_order_details[targetIndex].purchase_order,
-      customer_id: supplier.id,
-      customer_name: supplier.name,
-      customer_contact_id: supplier.contact_id,
-      delivery_address_id: supplier.delivery_address_id,
-    };
+    const updatedDetails = [...data.detail_rows];
+    updatedDetails[targetIndex] = {
+      ...updatedDetails[targetIndex],
+      purchase_order: {
+        ...updatedDetails[targetIndex].purchase_order,
+        customer_id: supplier.id,
+        customer_name: supplier.name,
+        customer_contact_id: supplier.contact_id,
+        delivery_address_id: supplier.delivery_address_id,
+      }
+    }
+    setData('detail_rows', updatedDetails);
 
-    updateDetail(targetIndex, 'purchase_order', purchaseOrder);
-    setSupplierContacts(supplier.contacts || []);
-    setSupplierAddresses(supplier.delivery_addresses || []);
+    setSupplierContacts(supplier.contacts || []); // TODO: indexの指定が抜けてる
+    setSupplierAddresses(supplier.delivery_addresses || []); // TODO: indexの指定が抜けてる
     setIsSupplierModalOpen(false);
   }
 
-  function addDetail() {
-    setData('sales_order_details', [
-      ...data.sales_order_details,
-      {
-        product_id: '',
-        product_name: '',
-        product_detail: '',
-        quantity: '',
-        unit_price: '',
-        tax_rate: 0.10,
-        is_tax_inclusive: false,
-        note: '',
-        purchase_order: {
-          customer_id: '',
-          customer_name: '',
-          customer_contact_id: '',
-          billing_address_id: '',
-          delivery_address_id: '',
-          purchase_in_charge_id: '',
-          purchase_order_details: {
-            quantity: '',
-            unit_price: '',
-            tax_rate: 0.10,
-            is_tax_inclusive: false,
-            note: '',
-          },
-        },
-      }
-    ])
+  function addDetailRow() {
+    setData('detail_rows', [
+      ...data.detail_rows,
+      defaultRowValues,
+    ]);
   }
 
   function removeSalesOrderDetail(indexToRemove) {
-    setData('sales_order_details', data.sales_order_details.filter((_, index) => index !== indexToRemove));
+    setData('detail_rows', data.detail_rows.filter((_, index) => index !== indexToRemove));
   }
 
-  function updateDetail(index, key, value) {
-    const updatedDetails = [...data.sales_order_details];
+  function updateSalesOrderDetail(index, key, value) {
+    const updatedDetails = [...data.detail_rows];
     updatedDetails[index] = {
       ...updatedDetails[index],
-      [key]: value
+      sales_order_detail: {
+        ...updatedDetails[index].sales_order_detail,
+        [key]: value,
+      }
     }
-    setData('sales_order_details', updatedDetails);
+    setData('detail_rows', updatedDetails);
   }
 
-  function updateDetailPurchaseOrder(index, key, value) {
-    const updatedDetails = [...data.sales_order_details];
-    updatedDetails[index].purchase_order = {
-      ...updatedDetails[index].purchase_order,
-      [key]: value
+  function updatePurchaseOrderDetail(index, key, value) {
+    const updatedDetails = [...data.detail_rows];
+    updatedDetails[index] = {
+      ...updatedDetails[index],
+      purchase_order_detail: {
+        ...updatedDetails[index].purchase_order_detail,
+        [key]: value,
+      }
     }
-    setData('sales_order_details', updatedDetails);
+    setData('detail_rows', updatedDetails);
   }
 
-  function updateDetailPurchaseOrderDetail(index, key, value) {
-    const updatedDetails = [...data.sales_order_details];
-    updatedDetails[index].purchase_order.purchase_order_details = {
-      ...updatedDetails[index].purchase_order.purchase_order_details,
-      [key]: value
+  function updatePurchaseOrder(index, key, value) {
+    const updatedDetails = [...data.detail_rows];
+    updatedDetails[index] = {
+      ...updatedDetails[index],
+      purchase_order: {
+        ...updatedDetails[index].purchase_order,
+        [key]: value,
+      }
     }
-    setData('sales_order_details', updatedDetails);
+    setData('detail_rows', updatedDetails);
   }
 
   return (
@@ -512,7 +505,7 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
         <div className="content-section">
           <div className="content-section-header">
             <div className="content-section-title">受注明細</div>
-            <button type="button" className="btn btn-secondary u-mr-3" onClick={addDetail}>+ 行を追加</button>
+            <button type="button" className="btn btn-secondary u-mr-3" onClick={addDetailRow}>+ 行を追加</button>
           </div>
           <div className="table-wrapper is-scrollable">
             <table className="table">
@@ -554,7 +547,7 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                 </tr>
               </thead>
               <tbody className="tbody">
-                {data.sales_order_details.map((detail, index) => (
+                {data.detail_rows.map((detail, index) => (
                   <Fragment key={index}>
                     <tr className="table-row">
                       <td className="td-cell col-fixed u-w-80" rowSpan={2}>
@@ -569,63 +562,63 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
 
                       <td className="td-cell">
                         <select
-                          value={detail.product_id}
-                          onChange={e => updateDetail(index, 'product_id', e.target.value)}
-                          className={`form-select ${errors[`sales_order_details.${index}.product_id`] ? 'is-invalid' : ''}`}
+                          value={detail.sales_order_detail.product_id}
+                          onChange={e => updateSalesOrderDetail(index, 'product_id', e.target.value)}
+                          className={`form-select ${errors[`detail_rows.${index}.sales_order_detail.product_id`] ? 'is-invalid' : ''}`}
                         >
                           <option value=""></option>
                           <OptionsList
                             options={productOptions.map(obj => ({ value: obj.id, label: obj.name }))}
                           />
                         </select>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.product_id`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.product_id`} />
                       </td>
 
                       <td className="td-cell">
                         <Input
                           type="text"
-                          value={detail.product_name}
-                          onChange={e => updateDetail(index, 'product_name', e.target.value)}
-                          error={errors[`sales_order_details.${index}.product_name`]}
+                          value={detail.sales_order_detail.product_name}
+                          onChange={e => updateSalesOrderDetail(index, 'product_name', e.target.value)}
+                          error={errors[`detail_rows.${index}.sales_order_detail.product_name`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.product_name`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.product_name`} />
                       </td>
 
                       <td className="td-cell">
                         <Input
                           type="text"
-                          value={detail.product_detail}
-                          onChange={e => updateDetail(index, 'product_detail', e.target.value)}
-                          error={errors[`sales_order_details.${index}.product_detail`]}
+                          value={detail.sales_order_detail.product_detail}
+                          onChange={e => updateSalesOrderDetail(index, 'product_detail', e.target.value)}
+                          error={errors[`detail_rows.${index}.sales_order_detail.product_detail`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.product_detail`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.product_detail`} />
                       </td>
 
                       <td className="td-cell">
                         <Input
                           type="number"
-                          value={detail.quantity}
-                          onChange={e => updateDetail(index, 'quantity', e.target.value)}
-                          error={errors[`sales_order_details.${index}.quantity`]}
+                          value={detail.sales_order_detail.quantity}
+                          onChange={e => updateSalesOrderDetail(index, 'quantity', e.target.value)}
+                          error={errors[`detail_rows.${index}.sales_order_detail.quantity`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.quantity`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.quantity`} />
                       </td>
 
                       <td className="td-cell">
                         <Input
                           type="number"
-                          value={detail.unit_price}
-                          onChange={e => updateDetail(index, 'unit_price', e.target.value)}
-                          error={errors[`sales_order_details.${index}.unit_price`]}
+                          value={detail.sales_order_detail.unit_price}
+                          onChange={e => updateSalesOrderDetail(index, 'unit_price', e.target.value)}
+                          error={errors[`detail_rows.${index}.sales_order_detail.unit_price`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.unit_price`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.unit_price`} />
                       </td>
 
                       <td className="td-cell">
                         <select
-                          value={detail.tax_rate}
-                          onChange={e => updateDetail(index, 'tax_rate', e.target.value)}
-                          className={`form-select ${errors[`sales_order_details.${index}.tax_rate`] ? 'is-invalid' : ''}`}
+                          value={detail.sales_order_detail.tax_rate}
+                          onChange={e => updateSalesOrderDetail(index, 'tax_rate', e.target.value)}
+                          className={`form-select ${errors[`detail_rows.${index}.sales_order_detail.tax_rate`] ? 'is-invalid' : ''}`}
                         >
                           <OptionsList
                             options={[
@@ -634,14 +627,14 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                             ]}
                           />
                         </select>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.tax_rate`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.tax_rate`} />
                       </td>
 
                       <td className="td-cell">
                         <select
-                          value={detail.is_tax_inclusive}
-                          onChange={e => updateDetail(index, 'is_tax_inclusive', e.target.value === 'true')}
-                          className={`form-select ${errors[`sales_order_details.${index}.is_tax_inclusive`] ? 'is-invalid' : ''}`}
+                          value={detail.sales_order_detail.is_tax_inclusive}
+                          onChange={e => updateSalesOrderDetail(index, 'is_tax_inclusive', e.target.value === 'true')}
+                          className={`form-select ${errors[`detail_rows.${index}.sales_order_detail.is_tax_inclusive`] ? 'is-invalid' : ''}`}
                         >
                           <OptionsList
                             options={[
@@ -650,17 +643,17 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                             ]}
                           />
                         </select>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.is_tax_inclusive`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.is_tax_inclusive`} />
                       </td>
 
                       <td className="td-cell">
                         <Input
                           type="text"
-                          value={detail.note}
-                          onChange={e => updateDetail(index, 'note', e.target.value)}
-                          error={errors[`sales_order_details.${index}.note`]}
+                          value={detail.sales_order_detail.note}
+                          onChange={e => updateSalesOrderDetail(index, 'note', e.target.value)}
+                          error={errors[`detail_rows.${index}.sales_order_detail.note`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.note`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.sales_order_detail.note`} />
                       </td>
                     </tr>
 
@@ -689,9 +682,9 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                             <ManageSearchIcon />
                           </button>
                         </div>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.customer_id`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order.customer_id`} />
                         <CustomSelect
-                          onChange={value => updateDetailPurchaseOrder(index, 'customer_contact_id', value)}
+                          onChange={value => updatePurchaseOrder(index, 'customer_contact_id', value)}
                           options={supplierContacts}
                           value={detail.purchase_order.customer_contact_id}
                           valueKey="id"
@@ -699,11 +692,11 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                           isClearable={true}
                           isSearchable={true}
                           placeholder="仕入先顧客..."
-                          error={errors[`sales_order_details.${index}.purchase_order.customer_contact_id`]}
+                          error={errors[`detail_rows.${index}.purchase_order.customer_contact_id`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.customer_contact_id`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order.customer_contact_id`} />
                         <CustomSelect
-                          onChange={value => updateDetailPurchaseOrder(index, 'delivery_address_id', value)}
+                          onChange={value => updatePurchaseOrder(index, 'delivery_address_id', value)}
                           options={supplierAddresses}
                           value={detail.purchase_order.delivery_address_id}
                           valueKey="id"
@@ -711,13 +704,13 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                           isClearable={true}
                           isSearchable={true}
                           placeholder="出荷元..."
-                          error={errors[`sales_order_details.${index}.purchase_order.delivery_address_id`]}
+                          error={errors[`detail_rows.${index}.purchase_order.delivery_address_id`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.delivery_address_id`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order.delivery_address_id`} />
                       </td>
                       <td className="td-cell">
                         <CustomSelect
-                          onChange={value => updateDetailPurchaseOrder(index, 'purchase_in_charge_id', value)}
+                          onChange={value => updatePurchaseOrder(index, 'purchase_in_charge_id', value)}
                           options={userOptions}
                           value={detail.purchase_order.purchase_in_charge_id}
                           valueKey="id"
@@ -725,33 +718,33 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                           isClearable={true}
                           isSearchable={true}
                           placeholder="..."
-                          error={errors[`sales_order_details.${index}.purchase_order.purchase_in_charge_id`]}
+                          error={errors[`detail_rows.${index}.purchase_order.purchase_in_charge_id`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_in_charge_id`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order.purchase_in_charge_id`} />
                       </td>
                       <td className="td-cell">
                         <Input
                           type="number"
-                          value={detail.purchase_order.purchase_order_details.quantity}
-                          onChange={e => updateDetailPurchaseOrderDetail(index, 'quantity', e.target.value)}
-                          error={errors[`sales_order_details.${index}.purchase_order.purchase_order_details.quantity`]}
+                          value={detail.purchase_order_detail.quantity}
+                          onChange={e => updatePurchaseOrderDetail(index, 'quantity', e.target.value)}
+                          error={errors[`detail_rows.${index}.purchase_order_detail.quantity`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_order_details.quantity`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order_detail.quantity`} />
                       </td>
                       <td className="td-cell">
                         <Input
                           type="number"
-                          value={detail.purchase_order.purchase_order_details.unit_price}
-                          onChange={e => updateDetailPurchaseOrderDetail(index, 'unit_price', e.target.value)}
-                          error={errors[`sales_order_details.${index}.purchase_order.purchase_order_details.unit_price`]}
+                          value={detail.purchase_order_detail.unit_price}
+                          onChange={e => updatePurchaseOrderDetail(index, 'unit_price', e.target.value)}
+                          error={errors[`detail_rows.${index}.purchase_order_detail.unit_price`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_order_details.unit_price`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order_detail.unit_price`} />
                       </td>
                       <td className="td-cell">
                         <select
-                          value={detail.purchase_order.purchase_order_details.tax_rate}
-                          onChange={e => updateDetailPurchaseOrderDetail(index, 'tax_rate', e.target.value)}
-                          className={`form-select ${errors[`sales_order_details.${index}.purchase_order.purchase_order_details.tax_rate`] ? 'is-invalid' : ''}`}
+                          value={detail.purchase_order_detail.tax_rate}
+                          onChange={e => updatePurchaseOrderDetail(index, 'tax_rate', e.target.value)}
+                          className={`form-select ${errors[`detail_rows.${index}.purchase_order_detail.tax_rate`] ? 'is-invalid' : ''}`}
                         >
                           <OptionsList
                             options={[
@@ -760,13 +753,13 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                             ]}
                           />
                         </select>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_order_details.tax_rate`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order_detail.tax_rate`} />
                       </td>
                       <td className="td-cell">
                         <select
-                          value={detail.purchase_order.purchase_order_details.is_tax_inclusive}
-                          onChange={e => updateDetailPurchaseOrderDetail(index, 'is_tax_inclusive', e.target.value)}
-                          className={`form-select ${errors[`sales_order_details.${index}.purchase_order.purchase_order_details.is_tax_inclusive`] ? 'is-invalid' : ''}`}
+                          value={detail.purchase_order_detail.is_tax_inclusive}
+                          onChange={e => updatePurchaseOrderDetail(index, 'is_tax_inclusive', e.target.value)}
+                          className={`form-select ${errors[`detail_rows.${index}.purchase_order_detail.is_tax_inclusive`] ? 'is-invalid' : ''}`}
                         >
                           <OptionsList
                             options={[
@@ -775,16 +768,16 @@ const Create = ({ userOptions, productOptions, productCategoryOptions, paymentTe
                             ]}
                           />
                         </select>
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_order_details.is_tax_inclusive`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order_detail.is_tax_inclusive`} />
                       </td>
                       <td className="td-cell">
                         <Input
                           type="text"
-                          value={detail.purchase_order.purchase_order_details.note}
-                          onChange={e => updateDetailPurchaseOrderDetail(index, 'note', e.target.value)}
-                          error={errors[`sales_order_details.${index}.purchase_order.purchase_order_details.note`]}
+                          value={detail.purchase_order_detail.note}
+                          onChange={e => updatePurchaseOrderDetail(index, 'note', e.target.value)}
+                          error={errors[`detail_rows.${index}.purchase_order_detail.note`]}
                         />
-                        <InvalidFeedback errors={errors} name={`sales_order_details.${index}.purchase_order.purchase_order_details.note`} />
+                        <InvalidFeedback errors={errors} name={`detail_rows.${index}.purchase_order_detail.note`} />
                       </td>
                     </tr>
                   </Fragment>


### PR DESCRIPTION
リクエストされる明細行を、次のような構造に変更。
（もともと、sales_order_detailの中にネストしていて複雑だった）

```php
$detailRows = [
    [
        'sales_order_detail'    => [],
        'purchase_order'        => [],
        'purchase_order_detail' => [],
    ],
    [
        'sales_order_detail'    => [],
        'purchase_order'        => [],
        'purchase_order_detail' => [],
    ],
    [
        'sales_order_detail'    => [],
        'purchase_order'        => [],
        'purchase_order_detail' => [],
    ],
    // ...省略
];
```