### PR TITLE
feat: PageSizeSelectorで動的に表示数を変更

### DIFF
--- a/src/app/Http/Controllers/CustomerContactController.php
+++ b/src/app/Http/Controllers/CustomerContactController.php
@@ -28,7 +28,7 @@ class CustomerContactController extends Controller
             ->searchByEmail($request->input('email'))
             ->searchByLeadSource($request->input('lead_source_id'))
             ->latest()
-            ->paginate(50)
+            ->paginate($request->input('page_size') ?? 100)
             ->withQueryString();
 
         return Inertia::render('CustomerContact/Index', [

--- a/src/app/Http/Controllers/CustomerController.php
+++ b/src/app/Http/Controllers/CustomerController.php
@@ -30,7 +30,7 @@ class CustomerController extends Controller
             ->searchByInCharge($request->input('in_charge_user_id'))
             ->searchByDeliveryAddress($request->input('delivery_address'))
             ->latest()
-            ->paginate(50)
+            ->paginate($request->input('page_size') ?? 100)
             ->withQueryString();
 
         return Inertia::render('Customer/Index', [

--- a/src/app/Http/Controllers/InquiryController.php
+++ b/src/app/Http/Controllers/InquiryController.php
@@ -36,7 +36,7 @@ class InquiryController extends Controller
             ->searchByInquiryType($request->input('inquiry_type_id'))
             ->searchByProduct($request->input('product_id'))
             ->latest('inquiry_date')
-            ->paginate(50)
+            ->paginate($request->input('page_size') ?? 100)
             ->withQueryString();
 
         return Inertia::render('Inquiry/Index', [

--- a/src/app/Http/Controllers/ProductController.php
+++ b/src/app/Http/Controllers/ProductController.php
@@ -21,7 +21,7 @@ class ProductController extends Controller
             ->searchByProductNumber($request->input('product_number'))
             ->searchByCategory($request->input('category_id'))
             ->orderByDisplayOrder()
-            ->paginate(100)
+            ->paginate($request->input('page_size') ?? 100)
             ->withQueryString();
 
         return Inertia::render('Product/Index', [

--- a/src/app/Http/Controllers/PurchaseOrderController.php
+++ b/src/app/Http/Controllers/PurchaseOrderController.php
@@ -21,7 +21,7 @@ class PurchaseOrderController extends Controller
     public function index(PurchaseOrderSearchRequest $request): Response
     {
         $query          = $this->getPurchaseOrdersQuery($request);
-        $purchaseOrders = $query->paginate(100)->withQueryString();
+        $purchaseOrders = $query->paginate($request->input('page_size') ?? 100)->withQueryString();
         $totals         = $this->calculateTotals($purchaseOrders->items());
 
         return Inertia::render('PurchaseOrder/Index', [

--- a/src/app/Http/Controllers/SalesActivityController.php
+++ b/src/app/Http/Controllers/SalesActivityController.php
@@ -28,7 +28,7 @@ class SalesActivityController extends Controller
             )
             ->searchByInCharge($request->input('in_charge_user_id'))
             ->latest('contact_date')
-            ->paginate(50);
+            ->paginate($request->input('page_size') ?? 100);
 
         return Inertia::render('SalesActivity/Index', [
             'salesActivities'      => $salesActivities,

--- a/src/app/Http/Controllers/SalesOrderController.php
+++ b/src/app/Http/Controllers/SalesOrderController.php
@@ -26,7 +26,7 @@ class SalesOrderController extends Controller
     public function index(SalesOrderSearchRequest $request): Response
     {
         $query       = $this->getSalesOrdersQuery($request);
-        $salesOrders = $query->paginate(100)->withQueryString();
+        $salesOrders = $query->paginate($request->input('page_size') ?? 100)->withQueryString();
         $totals      = $this->calculateTotals($salesOrders->items());
 
         return Inertia::render('SalesOrder/Index', [

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -23,7 +23,7 @@ class UserController extends Controller
             ->searchById($request->input('user_id'))
             ->searchByEmployeeCode($request->input('employee_code'))
             ->searchByEmail($request->input('email'))
-            ->paginate(50)
+            ->paginate($request->input('page_size') ?? 100)
             ->withQueryString();
 
         return Inertia::render('User/Index', [

--- a/src/resources/js/Components/PageSizeSelector.jsx
+++ b/src/resources/js/Components/PageSizeSelector.jsx
@@ -1,0 +1,25 @@
+import OptionsList from '@/Components/OptionsList';
+
+function PageSizeSelector({ pageSize, onChange,  }) {
+
+  return (
+    <div className="u-flex u-items-center u-ml-auto u-mr-2">
+      <div className="u-text-sm u-min-w-64">表示件数</div>
+      <select
+        value={pageSize}
+        onChange={onChange}
+        className="form-select u-min-w-88"
+      >
+        <OptionsList
+          options={[
+            { value: 100, label: '100件' },
+            { value: 200, label: '200件' },
+            { value: 500, label: '500件' },
+          ]}
+        />
+      </select>
+    </div>
+  );
+}
+
+export default PageSizeSelector;

--- a/src/resources/js/Pages/Customer/Index.jsx
+++ b/src/resources/js/Pages/Customer/Index.jsx
@@ -13,6 +13,7 @@ import ToggleFilterButton from '@/Components/ToggleFilterButton';
 
 import FilterForm from '@/Components/FilterForm';
 import CustomerFilter from './Partials/CustomerFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ customers, inChargeUserOptions }) => {
   const urlParams = route().params;
@@ -27,6 +28,7 @@ const Index = ({ customers, inChargeUserOptions }) => {
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     customer_id: urlParams.customer_id || '',
     address: urlParams.address || '',
@@ -42,6 +44,15 @@ const Index = ({ customers, inChargeUserOptions }) => {
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('customers.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -86,6 +97,12 @@ const Index = ({ customers, inChargeUserOptions }) => {
         <div className="record-count">
           {customers.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={customers} />
       </div>
 

--- a/src/resources/js/Pages/CustomerContact/Index.jsx
+++ b/src/resources/js/Pages/CustomerContact/Index.jsx
@@ -10,6 +10,7 @@ import ToggleFilterButton from '@/Components/ToggleFilterButton';
 
 import FilterForm from '@/Components/FilterForm';
 import ContactFilter from './Partials/ContactFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ customerContacts, leadSourceOptions }) => {
   const urlParams = route().params;
@@ -24,6 +25,7 @@ const Index = ({ customerContacts, leadSourceOptions }) => {
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     contact_id: urlParams.contact_id || '',
     customer_name: urlParams.customer_name || '',
@@ -38,6 +40,15 @@ const Index = ({ customerContacts, leadSourceOptions }) => {
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('contacts.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -63,6 +74,12 @@ const Index = ({ customerContacts, leadSourceOptions }) => {
         <div className="record-count">
           {customerContacts.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={customerContacts} />
       </div>
 

--- a/src/resources/js/Pages/Inquiry/Index.jsx
+++ b/src/resources/js/Pages/Inquiry/Index.jsx
@@ -12,7 +12,8 @@ import KeywordSearchForm from '@/Components/KeywordSearchForm';
 import InquiryTable from './Partials/InquiryTable';
 import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import FilterForm from '@/Components/FilterForm';
-import InquiryFilter from "./Partials/InquiryFilter";
+import InquiryFilter from './Partials/InquiryFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ inquiries, productOptions, inChargeUserOptions, inquiryTypeOptions, inquiryStatusOptions }) => {
   const urlParams = route().params;
@@ -26,6 +27,7 @@ const Index = ({ inquiries, productOptions, inChargeUserOptions, inquiryTypeOpti
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     inquiry_id: urlParams.inquiry_id || '',
     customer_info: urlParams.customer_info || '',
@@ -43,6 +45,15 @@ const Index = ({ inquiries, productOptions, inChargeUserOptions, inquiryTypeOpti
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('inquiries.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -88,6 +99,12 @@ const Index = ({ inquiries, productOptions, inChargeUserOptions, inquiryTypeOpti
         <div className="record-count">
           {inquiries.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={inquiries} />
       </div>
 

--- a/src/resources/js/Pages/Product/Index.jsx
+++ b/src/resources/js/Pages/Product/Index.jsx
@@ -8,6 +8,7 @@ import ProductTable from './Partials/ProductTable';
 import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import FilterForm from '@/Components/FilterForm';
 import ProductFilter from './Partials/ProductFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ products, categoryOptions }) => {
   const urlParams = route().params;
@@ -21,6 +22,7 @@ const Index = ({ products, categoryOptions }) => {
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     product_number: urlParams.product_number || '',
     category_id: urlParams.category_id || '',
@@ -32,6 +34,15 @@ const Index = ({ products, categoryOptions }) => {
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('products.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -60,6 +71,12 @@ const Index = ({ products, categoryOptions }) => {
         <div className="record-count">
           {products.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={products} />
       </div>
 

--- a/src/resources/js/Pages/PurchaseOrder/Index.jsx
+++ b/src/resources/js/Pages/PurchaseOrder/Index.jsx
@@ -10,6 +10,7 @@ import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import { formatCurrency } from '@/Utils/priceCalculator';
 import FilterForm from '@/Components/FilterForm';
 import PurchaseOrderFilter from './Partials/PurchaseOrderFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ purchaseOrders, userOptions, productCategoryOptions, totals }) => {
   const urlParams = route().params;
@@ -24,6 +25,7 @@ const Index = ({ purchaseOrders, userOptions, productCategoryOptions, totals }) 
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     start_date: urlParams.start_date || '',
     end_date: urlParams.end_date || '',
@@ -41,6 +43,15 @@ const Index = ({ purchaseOrders, userOptions, productCategoryOptions, totals }) 
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('purchase-orders.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -96,6 +107,12 @@ const Index = ({ purchaseOrders, userOptions, productCategoryOptions, totals }) 
         <div className="record-count">
           {purchaseOrders.total}件
         </div>
+
+        <PageSizeSelector
+          value={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+        
         <Pagination paginator={purchaseOrders} />
       </div>
 

--- a/src/resources/js/Pages/SalesActivity/Index.jsx
+++ b/src/resources/js/Pages/SalesActivity/Index.jsx
@@ -10,6 +10,7 @@ import SalesActivityTable from './Partials/SalesActivityTable';
 import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import FilterForm from '@/Components/FilterForm';
 import SalesActivityFilter from './Partials/SalesActivityFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ salesActivities, inChargeUserOptions }) => {
   const urlParams = route().params;
@@ -23,6 +24,7 @@ const Index = ({ salesActivities, inChargeUserOptions }) => {
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     start_date: urlParams.start_date || '',
     end_date: urlParams.end_date || '',
@@ -35,6 +37,15 @@ const Index = ({ salesActivities, inChargeUserOptions }) => {
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('sales-activities.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -68,6 +79,12 @@ const Index = ({ salesActivities, inChargeUserOptions }) => {
         <div className="record-count">
           {salesActivities.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={salesActivities} />
       </div>
 

--- a/src/resources/js/Pages/SalesOrder/Index.jsx
+++ b/src/resources/js/Pages/SalesOrder/Index.jsx
@@ -11,6 +11,7 @@ import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import { formatCurrency } from '@/Utils/priceCalculator';
 import FilterForm from '@/Components/FilterForm';
 import SalesOrderFilter from './Partials/SalesOrderFilter';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ salesOrders, userOptions, productCategoryOptions, totals }) => {
   const urlParams = route().params;
@@ -25,6 +26,7 @@ const Index = ({ salesOrders, userOptions, productCategoryOptions, totals }) => 
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     product_category_id: urlParams.product_category_id || '',
     product_name: urlParams.product_name || '',
@@ -42,6 +44,15 @@ const Index = ({ salesOrders, userOptions, productCategoryOptions, totals }) => 
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('sales-orders.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -117,6 +128,12 @@ const Index = ({ salesOrders, userOptions, productCategoryOptions, totals }) => 
         <div className="record-count">
           {salesOrders.total}件
         </div>
+
+        <PageSizeSelector
+          value={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+        
         <Pagination paginator={salesOrders} />
       </div>
 

--- a/src/resources/js/Pages/User/Index.jsx
+++ b/src/resources/js/Pages/User/Index.jsx
@@ -9,6 +9,7 @@ import UserTable from './Partials/UserTable';
 import ToggleFilterButton from '@/Components/ToggleFilterButton';
 import UserFilter from './Partials/UserFilter';
 import FilterForm from '@/Components/FilterForm';
+import PageSizeSelector from '@/Components/PageSizeSelector';
 
 const Index = ({ users, canAdmin }) => {
   const urlParams = route().params;
@@ -23,6 +24,7 @@ const Index = ({ users, canAdmin }) => {
   }, []);
 
   const { data, setData, get, errors } = useForm({
+    page_size: urlParams.page_size || 100,
     keyword: urlParams.keyword || '',
     user_id: urlParams.user_id || '',
     employee_code: urlParams.employee_code || '',
@@ -35,6 +37,15 @@ const Index = ({ users, canAdmin }) => {
       preserveState: true,
     });
   };
+
+  const [prevPageSize, setPrevPageSize] = useState(data.page_size);
+
+  if (data.page_size !== prevPageSize) {
+    get(route('users.index'), {
+      preserveState: true,
+    });
+    setPrevPageSize(data.page_size);
+  }
 
   return (
     <>
@@ -66,6 +77,12 @@ const Index = ({ users, canAdmin }) => {
         <div className="record-count">
           {users.total}件
         </div>
+
+        <PageSizeSelector
+          pageSize={data.page_size}
+          onChange={e => setData('page_size', e.target.value)}
+        />
+
         <Pagination paginator={users} />
       </div>
 

--- a/src/resources/sass/components/_pagination.scss
+++ b/src/resources/sass/components/_pagination.scss
@@ -2,7 +2,6 @@
   align-items: center;
   display: flex;
   justify-content: center;
-  margin-left: auto;
 }
 
 .pagination-link {


### PR DESCRIPTION
## Memo

セレクトボックスを変更した`onChange`で、`setData`と`submit`を同時に行おうとしても、`setData`が非同期処理のため完了するまえに`submit`されるためうまくいかない。`page_size`の状態管理をする必要がある。`useEffect`でもできそうだが問題がある。

### 🆖パターン

不要なuseEffectを使っている

初回ページ読み込み時にも、不要なのにこの処理が発火してしまう。

```jsx
  useEffect(() => {
    get(route('users.index'), {
      preserveState: true,
    });
  }, [data.page_size]);
```

### 🆗パターン

```jsx
  const [prevPageSize, setPrevPageSize] = useState(data.page_size);

  if (data.page_size !== prevPageSize) {
    get(route('users.index'), {
      preserveState: true,
    });
    setPrevPageSize(data.page_size);
  }
```

参考：[エフェクトは必要ないかもしれない – React](https://ja.react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes)
