### PR TITLE
refactor: shared dataの一部をコントローラーへ移動

### DIFF
--- a/src/app/Http/Controllers/CustomerController.php
+++ b/src/app/Http/Controllers/CustomerController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\AddressType;
+use App\Enums\SalesActivityStatus;
 use App\Http\Requests\CustomerSearchRequest;
 use App\Http\Requests\CustomerStoreRequest;
 use App\Http\Requests\CustomerUpdateRequest;
@@ -93,6 +94,7 @@ class CustomerController extends Controller
             'userOptions'       => User::active()->get(),
             'leadSourceOptions' => LeadSource::all(),
             'addressTypeOptions'    => AddressType::toArray(),
+            'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
         ]);
     }
 

--- a/src/app/Http/Controllers/CustomerController.php
+++ b/src/app/Http/Controllers/CustomerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\AddressType;
 use App\Http\Requests\CustomerSearchRequest;
 use App\Http\Requests\CustomerStoreRequest;
 use App\Http\Requests\CustomerUpdateRequest;
@@ -44,6 +45,7 @@ class CustomerController extends Controller
         return Inertia::render('Customer/Create', [
             'userOptions'       => User::active()->get(),
             'leadSourceOptions' => LeadSource::all(),
+            'addressTypeOptions'    => AddressType::toArray(),
         ]);
     }
 
@@ -90,6 +92,7 @@ class CustomerController extends Controller
             'customer'          => $customer,
             'userOptions'       => User::active()->get(),
             'leadSourceOptions' => LeadSource::all(),
+            'addressTypeOptions'    => AddressType::toArray(),
         ]);
     }
 
@@ -108,6 +111,7 @@ class CustomerController extends Controller
             'customer'          => $customer,
             'userOptions'       => User::active()->get(),
             'leadSourceOptions' => LeadSource::all(),
+            'addressTypeOptions'    => AddressType::toArray(),
         ]);
     }
 

--- a/src/app/Http/Controllers/InquiryController.php
+++ b/src/app/Http/Controllers/InquiryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\ContactMethod;
 use App\Enums\InquiryStatus;
 use App\Http\Requests\InquirySearchRequest;
 use App\Http\Requests\InquiryStoreRequest;
@@ -57,6 +58,7 @@ class InquiryController extends Controller
             'inquiryTypeOptions'     => InquiryType::all(),
             'inquiryStatusOptions'   => InquiryStatus::toArray(),
             'inChargeUserOptions'    => User::active()->get(),
+            'contactMethodOptions'   => ContactMethod::toArray(),
         ]);
     }
 
@@ -101,6 +103,7 @@ class InquiryController extends Controller
             'inquiryTypeOptions'     => InquiryType::all(),
             'inquiryStatusOptions'   => InquiryStatus::toArray(),
             'inChargeUserOptions'    => User::active()->get(),
+            'contactMethodOptions'   => ContactMethod::toArray(),
         ]);
     }
 

--- a/src/app/Http/Controllers/InquiryController.php
+++ b/src/app/Http/Controllers/InquiryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\InquiryStatus;
 use App\Http\Requests\InquirySearchRequest;
 use App\Http\Requests\InquiryStoreRequest;
 use App\Http\Requests\InquiryUpdateRequest;
@@ -44,6 +45,7 @@ class InquiryController extends Controller
             'inquiries'             => $inquiries,
             'productOptions'        => Product::hasInquiries()->get(),
             'inquiryTypeOptions'    => InquiryType::all(),
+            'inquiryStatusOptions'  => InquiryStatus::toArray(),
             'inChargeUserOptions'   => User::active()->hasInquiries()->get(),
         ]);
     }
@@ -53,6 +55,7 @@ class InquiryController extends Controller
         return Inertia::render('Inquiry/Create', [
             'productOptions'         => Product::all(),
             'inquiryTypeOptions'     => InquiryType::all(),
+            'inquiryStatusOptions'   => InquiryStatus::toArray(),
             'inChargeUserOptions'    => User::active()->get(),
         ]);
     }
@@ -96,6 +99,7 @@ class InquiryController extends Controller
             'inquiry'                => $inquiry,
             'productOptions'         => Product::all(),
             'inquiryTypeOptions'     => InquiryType::all(),
+            'inquiryStatusOptions'   => InquiryStatus::toArray(),
             'inChargeUserOptions'    => User::active()->get(),
         ]);
     }

--- a/src/app/Http/Controllers/ProductController.php
+++ b/src/app/Http/Controllers/ProductController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\ProductType;
 use App\Http\Requests\ProductSearchRequest;
 use App\Http\Requests\ProductStoreRequest;
 use App\Models\Product;
@@ -38,6 +39,7 @@ class ProductController extends Controller
         return Inertia::render('Product/Create', [
             'groupOptions'    => $groupOptions,
             'categoryOptions' => $categoryOptions,
+            'productTypeOptions'    => ProductType::toArray(),
         ]);
     }
 

--- a/src/app/Http/Controllers/SalesActivityController.php
+++ b/src/app/Http/Controllers/SalesActivityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\SalesActivityStatus;
 use App\Http\Requests\SalesActivitySearchRequest;
 use App\Http\Requests\SalesActivityStoreRequest;
 use App\Http\Requests\SalesActivityUpdateRequest;
@@ -34,6 +35,7 @@ class SalesActivityController extends Controller
         return Inertia::render('SalesActivity/Index', [
             'salesActivities'      => $salesActivities,
             'inChargeUserOptions'  => User::active()->hasSalesActivities()->get(),
+            'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
         ]);
     }
 
@@ -41,6 +43,7 @@ class SalesActivityController extends Controller
     {
         return Inertia::render('SalesActivity/Create', [
             'inChargeUserOptions' => User::active()->get(),
+            'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
         ]);
     }
 
@@ -71,6 +74,7 @@ class SalesActivityController extends Controller
         return Inertia::render('SalesActivity/Edit', [
             'salesActivity' => $salesActivity,
             'inChargeUserOptions' => User::active()->get(),
+            'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
         ]);
     }
 

--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Enums\ContactMethod;
 use App\Enums\PaymentTerm\BillingType;
 use App\Enums\PaymentTerm\CutoffDay;
 use App\Enums\PaymentTerm\PaymentDay;
@@ -65,7 +64,6 @@ class HandleInertiaRequests extends Middleware
                 'paymentDay'   => PaymentDay::toArray(),
                 'dayOffsets'   => PaymentDayOffset::toArray(),
             ],
-            'contactMethodOptions'  => ContactMethod::toArray(),
             'productTypeOptions'    => ProductType::toArray(),
         ]);
     }

--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,7 +3,6 @@
 namespace App\Http\Middleware;
 
 use App\Enums\ContactMethod;
-use App\Enums\InquiryStatus;
 use App\Enums\PaymentTerm\BillingType;
 use App\Enums\PaymentTerm\CutoffDay;
 use App\Enums\PaymentTerm\PaymentDay;
@@ -67,7 +66,6 @@ class HandleInertiaRequests extends Middleware
                 'paymentDay'   => PaymentDay::toArray(),
                 'dayOffsets'   => PaymentDayOffset::toArray(),
             ],
-            'inquiryStatusOptions'  => InquiryStatus::toArray(),
             'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
             'contactMethodOptions'  => ContactMethod::toArray(),
             'productTypeOptions'    => ProductType::toArray(),

--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -9,7 +9,6 @@ use App\Enums\PaymentTerm\PaymentDay;
 use App\Enums\PaymentTerm\PaymentDayOffset;
 use App\Enums\PaymentTerm\PaymentMonthOffset;
 use App\Enums\ProductType;
-use App\Enums\SalesActivityStatus;
 use App\Models\TaxRate;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -66,7 +65,6 @@ class HandleInertiaRequests extends Middleware
                 'paymentDay'   => PaymentDay::toArray(),
                 'dayOffsets'   => PaymentDayOffset::toArray(),
             ],
-            'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
             'contactMethodOptions'  => ContactMethod::toArray(),
             'productTypeOptions'    => ProductType::toArray(),
         ]);

--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -7,7 +7,6 @@ use App\Enums\PaymentTerm\CutoffDay;
 use App\Enums\PaymentTerm\PaymentDay;
 use App\Enums\PaymentTerm\PaymentDayOffset;
 use App\Enums\PaymentTerm\PaymentMonthOffset;
-use App\Enums\ProductType;
 use App\Models\TaxRate;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -64,7 +63,6 @@ class HandleInertiaRequests extends Middleware
                 'paymentDay'   => PaymentDay::toArray(),
                 'dayOffsets'   => PaymentDayOffset::toArray(),
             ],
-            'productTypeOptions'    => ProductType::toArray(),
         ]);
     }
 }

--- a/src/app/Http/Middleware/HandleInertiaRequests.php
+++ b/src/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Enums\AddressType;
 use App\Enums\ContactMethod;
 use App\Enums\InquiryStatus;
 use App\Enums\PaymentTerm\BillingType;
@@ -68,7 +67,6 @@ class HandleInertiaRequests extends Middleware
                 'paymentDay'   => PaymentDay::toArray(),
                 'dayOffsets'   => PaymentDayOffset::toArray(),
             ],
-            'addressTypeOptions'    => AddressType::toArray(),
             'inquiryStatusOptions'  => InquiryStatus::toArray(),
             'salesActivityStatusOptions'  => SalesActivityStatus::toArray(),
             'contactMethodOptions'  => ContactMethod::toArray(),


### PR DESCRIPTION
使用範囲が限定的なpropsをグローバルで渡すと、グローバル変数が煩雑で管理しにくくなる